### PR TITLE
Fix missing/outdated dependencies and remove postinst hack

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -4,7 +4,7 @@ Architecture: amd64
 Maintainer: Citrix Systems, Inc. <debian.package.support@citrix.com>
 Installed-Size: 23420
 Pre-Depends: debconf (>= 0.5)
-Depends: libc6-i386 (>= 2.7-1), lib32z1, nspluginwrapper
+Depends: libc6:i386 (>= 2.7-1), zlib1g:i386, libasound2:i386, nspluginwrapper, libxerces-c3.1:i386
 Section: utils
 Priority: extra
 Homepage: http://www.citrix.com

--- a/DEBIAN/postinst
+++ b/DEBIAN/postinst
@@ -2280,7 +2280,7 @@ UpdateMachineHWSuffix ()
 {
 	Arch=`uname -m`
 
-	echo $Arch|grep -E "i[0-9]86|x86_64" >/dev/null
+	echo $Arch|grep "i[0-9]86" >/dev/null
 	if [ $? -eq 0 ]; then
 		MachineArch=$IntelSuffix
 		return 0


### PR DESCRIPTION
The x86_64 fix in postinst was fixed upstream in v13 (see line 2289 of postinst)
